### PR TITLE
fixed the --save and other options which got no value. previously esc…

### DIFF
--- a/src/ProcessExecutor.php
+++ b/src/ProcessExecutor.php
@@ -54,7 +54,7 @@ class ProcessExecutor
      */
     public function compileCmdAsEscapedArray(string $params): array
     {
-        return $this->compileParamsArray($this->parseParamsString($params));
+        return $this->compileParamsArray($this->parseParamsString($params, true));
     }
 
     /**


### PR DESCRIPTION
…aper translated them into --save=1, not it works properly.